### PR TITLE
Add union type support for fragments

### DIFF
--- a/src/juxt/grab/alpha/execution.clj
+++ b/src/juxt/grab/alpha/execution.clj
@@ -21,7 +21,7 @@
   (case (::g/kind fragment-type)
     OBJECT (= object-type fragment-type)
     INTERFACE (throw (ex-info "TODO" {}))
-    UNION (throw (ex-info "TODO" {}))
+    UNION (boolean ((set (::g/member-types fragment-type)) (::g/name object-type)))
     (throw
      (ex-info
       "Unexpected fragment type kind"

--- a/test/juxt/grab/examples/fragment-example-query.graphql
+++ b/test/juxt/grab/examples/fragment-example-query.graphql
@@ -1,0 +1,15 @@
+{
+  heros {
+    ...heroFields
+  }
+}
+
+fragment heroFields on Hero {
+  ... on Alien {
+    name
+    tentacles
+  }
+  ... on Human {
+    name
+  }
+}


### PR DESCRIPTION
Relevant section in spec = https://spec.graphql.org/June2018/#DoesFragmentTypeApply()

